### PR TITLE
Add livebroadcasts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ categories = ["api-bindings", "multimedia::video"]
 [badges]
 travis-ci = { repository = "maxjoehnk/youtube-rs", branch = "master" }
 
+[features]
+default = ["readonly"]
+post = ["readonly"]
+readonly = []
+
 [dependencies]
 failure = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
 # youtube-api
 
 Provide an async api for the youtube api.
+
+Supprts:
+* search
+* playlists
+* livebroacasts (aka live streams)
+
+## APIs
+### Search
+
+### Playlists
+
+### livebroadcasts
+Function is in beta, see [examples](examples/pingpong.rs)
+
+Contians basic functionality to allow creationg of a chat bot.
+To allow posting messages to a livebroadcast requires the "post" feature.
+
+## Features
+### readonly (default)
+Uses the readonly scope
+
+### post
+Requires readonly and adds the ability to post to the livechat of a livebroadcast
+using the force-ssl scope
+

--- a/examples/pingpong.rs
+++ b/examples/pingpong.rs
@@ -1,0 +1,62 @@
+use youtube_api::YoutubeApi;
+use youtube_api::auth::stdio_login;
+use std::thread;
+use std::time;
+
+/// This example requires the "post" feature enabled otherwise it will
+/// return an error when it tries to post to the chat
+#[tokio::main]
+async fn main() {
+    let api = YoutubeApi::new_with_oauth(env!("YOUTUBE_API_KEY").to_string(),
+        env!("YOUTUBE_CLIENT_ID").to_string(),
+        env!("YOUTUBE_CLIENT_SECRET").to_string(),None).unwrap();
+    
+    api.login(stdio_login).await.unwrap();
+
+    // Assumes you have a single live broadcast running
+    let broadcasts = api.list_live_broadcasts(
+                youtube_api::models::LiveBroadcastRequestBuilder{max_results:Some(10),mine:Some(true)})
+            .await.unwrap();
+    let chat = &broadcasts.items[0].snippet.content_details.live_chat_id;
+
+    // Read all the messages in chat and ignore them
+    let thing = api.get_live_chat(
+                youtube_api::models::LiveChatRequestBuilder{live_chat_id:Some(chat.to_string()),page_token:None})
+            .await.unwrap();
+    let mut next = thing.next_page_token;
+
+    // Every 5 seconds read next set of messages (up to 500 messages)
+    // scan them for "!ping" and respond with "pong <name of person who sent ping>"    
+    loop {
+        let thing = api.get_live_chat(
+                youtube_api::models::LiveChatRequestBuilder{
+                    live_chat_id:Some(chat.to_string()),page_token:next
+                })
+            .await.unwrap();
+        next = thing.next_page_token;
+        for (cmd,name) in thing.items.iter()
+                            .map(|x|(&x.snippet.content_details.display_message , &x.author_details.display_name))
+                            .filter(|(x,_)|x.starts_with("!")) {
+            match cmd.as_str() {
+                "!ping" => {
+                    match api.send_live_chat(
+                        youtube_api::models::SendLiveChatRequestBuilder{live_chat_id:Some(chat.to_string())},
+                        youtube_api::models::SendLiveChatRequestBody{
+                            snippet:youtube_api::models::SendLiveChatRequestBodyContents{
+                                live_chat_id:Some(chat.to_string()),
+                                typed:Some("textMessageEvent".to_string()),
+                                text_message_details:youtube_api::models::SendLiveChatMessageDetails{
+                                    message_text:Some(format!("pong {}",name))
+                                }
+                                }}).await
+                    {
+                        Ok(_) => (),
+                        Err(err) => println!("Send live chat failed: {:?}",err)
+                    }
+                },
+                x => println!("unknown! {} ({})",x,name)
+            }
+        }
+        thread::sleep(time::Duration::from_millis(1000));
+    }
+}

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -21,7 +21,7 @@ impl YoutubeApi {
                 "https://www.googleapis.com/oauth2/v3/token".to_string(),
             )?),
         )
-            .set_redirect_url(RedirectUrl::new(
+            .set_redirect_uri(RedirectUrl::new(
                 redirect_uri.unwrap_or(CODE_REDIRECT_URI).to_string(),
             )?);
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,6 +11,7 @@ const SEARCH_URL: &str = "https://youtube.googleapis.com/youtube/v3/search";
 const LIST_PLAYLISTS_URL: &str = "https://youtube.googleapis.com/youtube/v3/playlists";
 const LIST_PLAYLIST_ITEMS_URL: &str = "https://youtube.googleapis.com/youtube/v3/playlistItems";
 const LIVE_BROADCASTS: &str = "https://youtube.googleapis.com/youtube/v3/liveBroadcasts";
+const LIVE_CHAT: &str = "https://youtube.googleapis.com/youtube/v3/liveChat/messages";
 
 #[derive(Debug, Clone)]
 pub(crate) struct YoutubeOAuth {
@@ -79,6 +80,14 @@ impl YoutubeApi {
         Ok(response)
     }
 
+    pub async fn get_live_chat(&self, request: LiveChatRequestBuilder) 
+        -> Result<LiveChatResponse, failure::Error> {
+        let request = request.build(&self.api_key);
+        let response = self.api_get(LIVE_CHAT, request)
+            .await?;
+        Ok(response)
+    }
+
     async fn api_get<S: Into<String>, T: Serialize, TResponse: DeserializeOwned>(
         &self,
         url: S,
@@ -129,10 +138,73 @@ impl YoutubeApi {
         where TResponse : DeserializeOwned
     {
         if response.error_for_status_ref().is_ok() {
-            let res = response.json().await?;
-            Ok(res)
+            let res = response.text().await?;
+            log::debug!("response text {}",res);
+            let json = serde_json::from_str(&res)?;
+            Ok(json)
         } else {
-            let err: GoogleErrorResponse = response.json().await?;
+            let res = response.text().await?;
+            log::error!("{:?}", res);
+            let err: GoogleErrorResponse = serde_json::from_str(&res)?;
+            log::error!("{:?}", err);
+            Err(err.error.into())
+        }
+    }
+
+    #[cfg(not(feature="post"))]
+    pub async fn send_live_chat(&self, _request: SendLiveChatRequestBuilder, _body: SendLiveChatRequestBody) 
+        -> Result<bool, failure::Error> {
+            Err(failure::format_err!("feature disabled"))
+    }
+
+    #[cfg(feature="post")]
+    pub async fn send_live_chat(&self, request: SendLiveChatRequestBuilder, body: SendLiveChatRequestBody) 
+        -> Result<bool, failure::Error> {
+        let request = request.build(&self.api_key);
+        let response = self.api_post(LIVE_CHAT, request,body)
+            .await?;
+        Ok(response)
+    }
+
+    #[cfg(feature="post")]
+    async fn api_post<S: Into<String>, T: Serialize, B: Serialize>(
+        &self,
+        url: S,
+        params: T,
+        body: B
+    ) -> Result<bool, Error> {
+        let req = self.client.post(&url.into()).query(&params).json(&body);
+        let res = if let Some(oauth) = self.oauth.as_ref() {
+            if oauth.token.requires_new_token().await {
+                oauth.token.refresh(&oauth.client).await?;
+            }
+            let res = req
+                .try_clone()
+                .unwrap()
+                .bearer_auth(oauth.token.get_auth_header().await?)
+                .send()
+                .await?
+                .error_for_status();
+            match res {
+                Ok(res) => Ok(res),
+                Err(err) => Err(err)
+                
+            }
+        } else {
+            Ok(req.send().await?)
+        }?;
+        YoutubeApi::handle_post_error(res).await
+    }
+
+    #[cfg(feature="post")]
+    async fn handle_post_error(response: reqwest::Response) -> Result<bool, Error>
+    {
+        if response.error_for_status_ref().is_ok() {
+            Ok(true)
+        } else {
+            let res = response.text().await?;
+            println!("ERROR TEXT {}",res);
+            let err: GoogleErrorResponse = serde_json::from_str(&res)?;
             log::error!("{:?}", err);
 
             Err(err.error.into())

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -10,6 +10,7 @@ use serde::de::DeserializeOwned;
 const SEARCH_URL: &str = "https://youtube.googleapis.com/youtube/v3/search";
 const LIST_PLAYLISTS_URL: &str = "https://youtube.googleapis.com/youtube/v3/playlists";
 const LIST_PLAYLIST_ITEMS_URL: &str = "https://youtube.googleapis.com/youtube/v3/playlistItems";
+const LIVE_BROADCASTS: &str = "https://youtube.googleapis.com/youtube/v3/liveBroadcasts";
 
 #[derive(Debug, Clone)]
 pub(crate) struct YoutubeOAuth {
@@ -57,16 +58,24 @@ impl YoutubeApi {
     }
 
     pub async fn list_playlists(&self, request: ListPlaylistsRequestBuilder) -> Result<ListPlaylistsResponse, failure::Error> {
-        let request = request.build();
+        let request = request.build(&self.api_key);
         let response = self.api_get(LIST_PLAYLISTS_URL, request).await?;
 
         Ok(response)
     }
 
     pub async fn list_playlist_items(&self, request: ListPlaylistItemsRequestBuilder) -> Result<ListPlaylistItemsResponse, failure::Error> {
-        let request = request.build();
+        let request = request.build(&self.api_key);
         let response = self.api_get(LIST_PLAYLIST_ITEMS_URL, request).await?;
 
+        Ok(response)
+    }
+
+    pub async fn list_live_broadcasts(&self, request: LiveBroadcastRequestBuilder) 
+        -> Result<ListLiveBroadcastResponse, failure::Error> {
+        let request = request.build(&self.api_key);
+        let response = self.api_get(LIVE_BROADCASTS, request)
+            .await?;
         Ok(response)
     }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -7,7 +7,11 @@ use oauth2::{
     AuthorizationCode, CsrfToken, PkceCodeChallenge, PkceCodeVerifier, Scope,
 };
 
-static SCOPE: &str = "https://www.googleapis.com/auth/youtube.readonly";
+static SCOPE1: &str = "https://www.googleapis.com/auth/youtube.readonly";
+#[cfg(feature = "post")]
+static SCOPE2: &str = "https://www.googleapis.com/auth/youtube.force-ssl";
+#[cfg(not(feature = "post"))]
+static SCOPE2: &str = "";
 
 /**
  * Prints the authorize url to stdout and waits for the authorization code from stdin
@@ -27,11 +31,11 @@ pub(crate) fn get_oauth_url(client: &BasicClient) -> (String, PkceCodeVerifier) 
 
     let (authorize_url, _) = client
         .authorize_url(CsrfToken::new_random)
-        .add_scope(Scope::new(SCOPE.to_string()))
+        .add_scope(Scope::new(SCOPE1.to_string()))
+        .add_scope(Scope::new(SCOPE2.to_string()))
         .set_pkce_challenge(pkce_code_challenge)
         .add_extra_param("access_type", "offline")
         .url();
-
     (authorize_url.to_string(), pkce_code_verifier)
 }
 

--- a/src/models/livebroadcasts/mod.rs
+++ b/src/models/livebroadcasts/mod.rs
@@ -1,0 +1,5 @@
+mod request;
+mod response;
+
+pub use self::request::*;
+pub use self::response::*;

--- a/src/models/livebroadcasts/request.rs
+++ b/src/models/livebroadcasts/request.rs
@@ -1,0 +1,27 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveBroadcastRequestBuilder {
+    pub max_results: Option<u64>,
+    pub mine: Option<bool>
+}
+
+impl LiveBroadcastRequestBuilder {
+    pub(crate) fn build<S: Into<String>>(self, key : S) -> LiveBroadcastRequest {
+        LiveBroadcastRequest {
+            part: String::from("snippet,contentDetails"),
+            key: key.into(),
+            builder: self
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveBroadcastRequest {
+    part: String,
+    key: String,
+    #[serde(flatten)]
+    builder: LiveBroadcastRequestBuilder
+}

--- a/src/models/livebroadcasts/request.rs
+++ b/src/models/livebroadcasts/request.rs
@@ -25,3 +25,80 @@ pub struct LiveBroadcastRequest {
     #[serde(flatten)]
     builder: LiveBroadcastRequestBuilder
 }
+
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveChatRequestBuilder {
+    pub live_chat_id: Option<String>,
+    pub page_token: Option<String>
+}
+
+impl LiveChatRequestBuilder {
+    pub(crate) fn build<S: Into<String>>(self, key : S) -> LiveChatRequest {
+        LiveChatRequest {
+            part: String::from("snippet,authorDetails"),
+            key: key.into(),
+            builder: self
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveChatRequest {
+    part: String,
+    key: String,
+    #[serde(flatten)]
+    builder: LiveChatRequestBuilder
+}
+
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SendLiveChatRequestBuilder {
+    pub live_chat_id: Option<String>,
+}
+
+
+impl SendLiveChatRequestBuilder {
+    
+    #[cfg(feature="post")]
+    pub(crate) fn build<S: Into<String>>(self, key : S) -> SendLiveChatRequest {
+        SendLiveChatRequest {
+            part: String::from("snippet"),
+            key: key.into(),
+            builder: self
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendLiveChatRequest {
+    part: String,
+    key: String,    
+    #[serde(flatten)]
+    builder: SendLiveChatRequestBuilder
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SendLiveChatMessageDetails {
+    pub message_text: Option<String>
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SendLiveChatRequestBody {
+    pub snippet: SendLiveChatRequestBodyContents
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SendLiveChatRequestBodyContents {
+    pub live_chat_id: Option<String>,
+    #[serde(rename="type")]
+    pub typed: Option<String>,
+    pub text_message_details: SendLiveChatMessageDetails
+}

--- a/src/models/livebroadcasts/response.rs
+++ b/src/models/livebroadcasts/response.rs
@@ -52,7 +52,27 @@ pub struct LiveChatSnippet {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthorDetails {
-    pub display_name: String
+    #[serde(flatten)]
+    pub author_details_id: AuthorDetailsId,
+    pub is_chat_moderator: bool,
+    pub is_chat_owner: bool,    
+}
+
+///
+/// AuthorDetailsId contains just the display name and
+/// the channel ID in a hashable structure.
+/// This makes it easy to store a hash that uniquely identifies
+/// a person based on their current display name. This means
+/// that an application doesn't track display name changes.
+/// If an application wants to track display name changes then 
+/// use just the channel ID
+/// (and deal with any privacy concerns associated)
+///
+#[derive(Clone, Debug, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorDetailsId {
+    pub display_name: String,
+    pub channel_id: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/models/livebroadcasts/response.rs
+++ b/src/models/livebroadcasts/response.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+use crate::models::{Response, Snippet, Id};
+
+pub type ListLiveBroadcastResponse = Response<LiveBroadcastResource>;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveBroadcastResource {
+    pub kind: String,
+    pub etag: String,
+    pub id: String,
+    pub snippet: LiveBroadcastSnippet,
+    pub content_details: LiveBroadcastContentDetails
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveBroadcastSnippet {
+    pub resource_id: Id,
+    #[serde(flatten)]
+    pub inner: Snippet
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveBroadcastContentDetails {
+    pub video_id: String,
+    #[deprecated]
+    pub start_at: Option<String>,
+    #[deprecated]
+    pub end_at: Option<String>,
+    pub note: Option<String>,
+    pub video_published_at: String
+}

--- a/src/models/livebroadcasts/response.rs
+++ b/src/models/livebroadcasts/response.rs
@@ -1,8 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use crate::models::{Response, Snippet, Id};
+use crate::models::{Response, Snippet};
 
 pub type ListLiveBroadcastResponse = Response<LiveBroadcastResource>;
+pub type LiveChatResponse = Response<LiveChatResource>;
+pub type SendLiveChatResponse = Response<SendLiveChatResource>;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -11,25 +13,56 @@ pub struct LiveBroadcastResource {
     pub etag: String,
     pub id: String,
     pub snippet: LiveBroadcastSnippet,
-    pub content_details: LiveBroadcastContentDetails
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LiveBroadcastSnippet {
-    pub resource_id: Id,
     #[serde(flatten)]
-    pub inner: Snippet
+    pub inner: Snippet,
+    #[serde(flatten)]
+    pub content_details: LiveBroadcastContentDetails
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LiveBroadcastContentDetails {
-    pub video_id: String,
-    #[deprecated]
-    pub start_at: Option<String>,
-    #[deprecated]
-    pub end_at: Option<String>,
-    pub note: Option<String>,
-    pub video_published_at: String
+    pub scheduled_start_time: String,
+    pub live_chat_id: String,
+    pub actual_start_time: String,
+    pub is_default_broadcast: bool
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveChatResource {
+    pub kind: String,
+    pub etag: String,
+    pub snippet: LiveChatSnippet,
+    pub author_details: AuthorDetails
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveChatSnippet {
+    #[serde(flatten)]
+    pub content_details: LiveChatContentDetails
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorDetails {
+    pub display_name: String
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveChatContentDetails {
+    pub display_message: String
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendLiveChatResource {
+    
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -51,6 +51,11 @@ pub enum Id {
         #[serde(rename = "playlistId")]
         playlist_id: String
     },
+    #[serde(rename = "youtube#liveChatMessage")]
+    LiveChatId {
+        #[serde(rename = "id")]
+        livechat_id: String
+    }
 }
 
 impl Id {
@@ -59,6 +64,7 @@ impl Id {
             Id::VideoId { video_id } => video_id,
             Id::ChannelId { channel_id } => channel_id,
             Id::PlaylistId { playlist_id } => playlist_id,
+            Id::LiveChatId { livechat_id } => livechat_id
         }
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -4,12 +4,14 @@ mod error;
 mod metadata;
 mod search;
 mod playlists;
+mod livebroadcasts;
 mod snippet;
 
 pub use self::error::*;
 pub use self::metadata::*;
 pub use self::search::*;
 pub use self::playlists::*;
+pub use self::livebroadcasts::*;
 pub use self::snippet::*;
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/models/playlists/request.rs
+++ b/src/models/playlists/request.rs
@@ -11,9 +11,10 @@ pub struct ListPlaylistsRequestBuilder {
 }
 
 impl ListPlaylistsRequestBuilder {
-    pub(crate) fn build(self) -> ListPlaylistsRequest {
+    pub(crate) fn build<S: Into<String>>(self, key : S) -> ListPlaylistsRequest {
         ListPlaylistsRequest {
             part: String::from("snippet"),
+            key: key.into(),
             builder: self
         }
     }
@@ -23,10 +24,10 @@ impl ListPlaylistsRequestBuilder {
 #[serde(rename_all = "camelCase")]
 pub struct ListPlaylistsRequest {
     part: String,
+    key : String,
     #[serde(flatten)]
     builder: ListPlaylistsRequestBuilder
 }
-
 
 #[derive(Debug, Clone, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -36,9 +37,10 @@ pub struct ListPlaylistItemsRequestBuilder {
 }
 
 impl ListPlaylistItemsRequestBuilder {
-    pub(crate) fn build(self) -> ListPlaylistItemsRequest {
+    pub(crate) fn build<S: Into<String>>(self, key : S) -> ListPlaylistItemsRequest {
         ListPlaylistItemsRequest {
             part: String::from("snippet,contentDetails"),
+            key: key.into(),
             builder: self
         }
     }
@@ -48,6 +50,7 @@ impl ListPlaylistItemsRequestBuilder {
 #[serde(rename_all = "camelCase")]
 pub struct ListPlaylistItemsRequest {
     part: String,
+    key: String,
     #[serde(flatten)]
     builder: ListPlaylistItemsRequestBuilder
 }

--- a/src/models/snippet.rs
+++ b/src/models/snippet.rs
@@ -10,9 +10,16 @@ pub struct Snippet {
     pub title: String,
     pub description: String,
     pub thumbnails: HashMap<String, Thumbnail>,
-    pub channel_title: String,
+    pub channel_title: Option<String>,
     pub live_broadcast_content: Option<String>
 }
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveChatSnippet {
+    pub display_message: String
+}
+
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Thumbnail {


### PR DESCRIPTION
Have added the ability to monitor and contribute to livechat for livebroadcasts. 
Adds the "post" feature which requests the necessary scope for posting to livechat. 
Updated README and added example to illustrate how to create a chatbot.